### PR TITLE
Do not override the linger option on explicit dispose

### DIFF
--- a/src/Castle.Zmq/Socket.cs
+++ b/src/Castle.Zmq/Socket.cs
@@ -59,6 +59,7 @@
 					throw;
 				}
 			}
+			this.SetOption(SocketOpt.LINGER, 0);
 		}
 
 		~Socket()
@@ -260,7 +261,10 @@
 
 			_disposed = true;
 
-			TryCancelLinger();
+			if (isDispose)
+			{
+				TryCancelLinger();
+			}
 
 			var res = Native.Socket.zmq_close(this.SocketPtr);
 			if (res == Native.ErrorCode)


### PR DESCRIPTION
When socket is not closed from garbage collector I think the linger set by the user should be respected.

Linger is set to 0 in the constructor for any programs depending on this value when calling dispose
